### PR TITLE
Eliminate restriction to nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ documentation = "https://docs.rs/xray"
 homepage = "https://github.com/softprops/xray"
 repository = "https://github.com/softprops/xray"
 
+[features]
+nightly = []
+
 [dependencies]
 bytes = "1.4.0"
 http = "0.2.8"

--- a/benches/bench_ids.rs
+++ b/benches/bench_ids.rs
@@ -1,5 +1,6 @@
 // run cargo +nightly bench
 
+#![cfg(feature = "nightly")]
 #![feature(test)]
 extern crate test;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(is_some_and)]
 #![warn(missing_docs)]
 //#![deny(warnings)]
 //! Provides a client interface for [AWS X-Ray](https://aws.amazon.com/xray/)


### PR DESCRIPTION
I just made a few adjustments that makes this library usable in the Stable toolchain. `is_some_and` is in stable as of `rustc` 1.77.2, so that feature macro could be removed entirely. Use of the nightly bencher is now blocked behind a feature flag called "nightly".

Thank you for writing this little library! I'm new to Rust myself, so doing all this on my own was daunting. I hope these changes can help others who come along and find trouble with the feature macro like I did. Please let me know if you'd like to see any other changes!